### PR TITLE
Fixes for multiple classes

### DIFF
--- a/MiloLib/Assets/DirectoryMeta.cs
+++ b/MiloLib/Assets/DirectoryMeta.cs
@@ -715,10 +715,13 @@ namespace MiloLib.Assets
                     entry.isProxy = true;
                     entry.obj = new ObjectDir(0).Read(reader, true, this, entry);
 
-                    dir = new DirectoryMeta();
-                    dir.platform = platform;
-                    dir.Read(reader);
-                    entry.dir = dir;
+                    if (entry.name.value != "barks")
+                    {
+                        dir = new DirectoryMeta();
+                        dir.platform = platform;
+                        dir.Read(reader);
+                        entry.dir = dir;
+                    }
                     break;
                 case "OverdriveMeterDir":
                     Debug.WriteLine("Reading entry OverdriveMeterDir " + entry.name.value);
@@ -1337,7 +1340,10 @@ namespace MiloLib.Assets
                 case "ObjectDir":
                     ((ObjectDir)entry.obj).Write(writer, true, this, entry);
                     entry.isProxy = false;
-                    entry.dir.Write(writer);
+                    if (entry.dir != null)
+                    {
+                        entry.dir.Write(writer);
+                    }
                     break;
                 case "OverdriveMeterDir":
                     ((OverdriveMeterDir)entry.obj).Write(writer, true, this, entry);

--- a/MiloLib/Assets/Ham/MoveDir.cs
+++ b/MiloLib/Assets/Ham/MoveDir.cs
@@ -35,16 +35,16 @@ namespace MiloLib.Assets.Ham
 
             base.Read(reader, false, parent, entry);
 
-            if (entry != null && !entry.isProxy) {
-                mMoveOverlayEnabled = reader.ReadBoolean();
-                mDebugNodeTypes = reader.ReadInt32();
-                mImportClipPath = Symbol.Read(reader);
-                mFilterVersion = Symbol.Read(reader);
+            mMoveOverlayEnabled = reader.ReadBoolean();
+            mDebugNodeTypes = reader.ReadInt32();
+            mImportClipPath = Symbol.Read(reader);
+
+            if (entry != null && entry.isProxy)
+            {
+                unkBool = reader.ReadBoolean();
             }
-            else {
-                // there is prooooobably some fields here but ive never seen them be anything but empty
-                reader.ReadBlock(25);
-            }
+
+            mFilterVersion = Symbol.Read(reader);
 
             if (standalone)
                 if ((reader.Endianness == Endian.BigEndian ? 0xADDEADDE : 0xDEADDEAD) != reader.ReadUInt32()) throw new Exception("Got to end of standalone asset but didn't find the expected end bytes, read likely did not succeed");
@@ -58,17 +58,16 @@ namespace MiloLib.Assets.Ham
 
             base.Write(writer, false, parent, entry);
 
-            if (entry != null && !entry.isProxy)
+            writer.WriteBoolean(mMoveOverlayEnabled);
+            writer.WriteInt32(mDebugNodeTypes);
+            Symbol.Write(writer, mImportClipPath);
+            if (entry != null && entry.isProxy)
             {
-                writer.WriteUInt32(unkInt1);
-                writer.WriteUInt32(unkInt2);
-                writer.WriteUInt32(unkInt3);
-                writer.WriteUInt32(unkInt4);
+                writer.WriteBoolean(unkBool);
             }
-            else
-            {
-                writer.WriteBlock(new byte[25]);
-            }
+            Symbol.Write(writer, mFilterVersion);
+
+
 
             if (standalone)
                 writer.WriteBlock(new byte[4] { 0xAD, 0xDE, 0xAD, 0xDE });

--- a/MiloLib/Assets/Rnd/RndBitmap.cs
+++ b/MiloLib/Assets/Rnd/RndBitmap.cs
@@ -25,6 +25,8 @@ namespace MiloLib.Assets.Rnd
         }
         public byte revision;
 
+        public uint? uknownData;
+
         public byte bpp;
 
         public TextureEncoding encoding;
@@ -56,6 +58,11 @@ namespace MiloLib.Assets.Rnd
                 throw new UnsupportedAssetRevisionException("RndBitmap", revision);
             }
 
+            if (revision == 2)
+            {
+                uknownData = reader.ReadUInt32();
+            }
+
             bpp = reader.ReadByte();
 
             encoding = (TextureEncoding)reader.ReadUInt32();
@@ -70,7 +77,15 @@ namespace MiloLib.Assets.Rnd
             wiiAlphaNum = reader.ReadUInt16();
 
             // skip empty bytes
-            reader.BaseStream.Position += 17;
+            if (revision == 2)
+            {
+                reader.BaseStream.Position += 13;
+            }
+            else
+            {
+                reader.BaseStream.Position += 17;
+            }
+
 
             if (encoding == TextureEncoding.RGBA && (bpp == 4 || bpp == 8))
             {
@@ -105,6 +120,11 @@ namespace MiloLib.Assets.Rnd
         {
             writer.WriteByte(revision);
 
+            if (uknownData != null)
+            {
+                writer.WriteUInt32(uknownData.Value);
+            }
+
             writer.WriteByte(bpp);
 
             writer.WriteUInt32((uint)encoding);
@@ -118,8 +138,16 @@ namespace MiloLib.Assets.Rnd
 
             writer.WriteUInt16(wiiAlphaNum);
 
-            // write 17 empty bytes
-            writer.WriteBlock(new byte[17]);
+            // write 13 empty bytes
+            if (revision == 2)
+            {
+                writer.WriteBlock(new byte[13]);
+            }
+            else
+            {
+                writer.WriteBlock(new byte[17]);
+            }
+
 
             foreach (List<byte> texture in textures)
             {


### PR DESCRIPTION
Fixes:
* Reading/Writing MoveDir
* Reading/Writing ObjectDir in DirectoryMeta entry
* Reading RndBitmap
* Reading SynthSample

for DC3-era revisions.